### PR TITLE
fix: Add redirect parameter support for indexers

### DIFF
--- a/plugins/modules/prowlarr_indexer.py
+++ b/plugins/modules/prowlarr_indexer.py
@@ -35,6 +35,9 @@ options:
         description: Protocol.
         choices: [ "torrent", "usenet" ]
         type: str
+    redirect:
+        description: Redirect flag.
+        type: bool
     update_secrets:
         description: Flag to force update of secret fields.
         type: bool
@@ -61,6 +64,7 @@ EXAMPLES = r'''
     config_contract: "NewznabSettings"
     implementation: "Newznab"
     protocol: "usenet"
+    redirect: true
     fields:
     - name: "baseUrl"
       value: "https://lolo.sickbeard.com"
@@ -119,6 +123,11 @@ protocol:
     returned: always
     type: str
     sample: "torrent"
+redirect:
+    description: Redirect flag.
+    returned: always
+    type: bool
+    sample: true
 tags:
     description: Tag list.
     type: list
@@ -150,6 +159,7 @@ def is_changed(status, want):
             want.config_contract != status.config_contract or
             want.implementation != status.implementation or
             want.protocol != status.protocol or
+            want.redirect != status.redirect or
             want.tags != status.tags):
         return True
 
@@ -170,6 +180,7 @@ def init_module_args():
         config_contract=dict(type='str'),
         implementation=dict(type='str'),
         protocol=dict(type='str', choices=['usenet', 'torrent']),
+        redirect=dict(type='bool'),
         tags=dict(type='list', elements='int', default=[]),
         fields=dict(type='list', elements='dict', options=field_helper.field_args),
         state=dict(default='present', type='str', choices=['present', 'absent']),
@@ -274,6 +285,7 @@ def run_module():
         config_contract=module.params['config_contract'],
         implementation=module.params['implementation'],
         protocol=module.params['protocol'],
+        redirect=module.params['redirect'],
         tags=module.params['tags'],
         fields=field_helper.populate_fields(module.params['fields']),
     )

--- a/tests/integration/targets/prowlarr_indexer/tasks/main.yml
+++ b/tests/integration/targets/prowlarr_indexer/tasks/main.yml
@@ -8,6 +8,7 @@
     config_contract: NewznabSettings
     implementation: Newznab
     protocol: usenet
+    redirect: true
     fields:
       - name: baseUrl
         value: https://lolo.sickbeard.com
@@ -22,6 +23,7 @@
   ansible.builtin.assert:
     that:
       - result['implementation'] == 'Newznab'
+      - result['redirect'] == true
 # ----------------------------------------------------------------------------
 - name: Edit already present indexer
   devopsarr.prowlarr.prowlarr_indexer:
@@ -32,6 +34,7 @@
     config_contract: NewznabSettings
     implementation: Newznab
     protocol: usenet
+    redirect: true
     fields:
       - name: baseUrl
         value: https://lolo.sickbeard.com
@@ -56,6 +59,7 @@
     config_contract: NewznabSettings
     implementation: Newznab
     protocol: usenet
+    redirect: true
     fields:
       - name: baseUrl
         value: https://lolo.sickbeard.com
@@ -80,6 +84,7 @@
     config_contract: NewznabSettings
     implementation: Newznab
     protocol: usenet
+    redirect: true
     fields:
       - name: baseUrl
         value: https://lolo.sickbeard.com
@@ -95,6 +100,33 @@
   ansible.builtin.assert:
     that:
       - result.changed == true
+# ----------------------------------------------------------------------------
+- name: Test redirect change
+  devopsarr.prowlarr.prowlarr_indexer:
+    name: Example
+    enable: false
+    priority: 10
+    app_profile_id: 1
+    config_contract: NewznabSettings
+    implementation: Newznab
+    protocol: usenet
+    redirect: false
+    fields:
+      - name: baseUrl
+        value: https://lolo.sickbeard.com
+      - name: apiPath
+        value: /api
+      - name: apiKey
+        value: apiKey1234
+    update_secrets: true
+    prowlarr_api_key: "{{ prowlarr_api_key }}"
+    prowlarr_url: "{{ prowlarr_url }}"
+  register: result
+- name: Assert redirect change detected
+  ansible.builtin.assert:
+    that:
+      - result.changed == true
+      - result['redirect'] == false
 # ----------------------------------------------------------------------------
 - name: Delete indexer
   devopsarr.prowlarr.prowlarr_indexer:


### PR DESCRIPTION
Add support for the redirect parameter in prowlarr_indexer module. This parameter is now required by Prowlarr v2.0.5.5160+ for Usenet indexers.

Changes:
 - Add redirect parameter to module documentation and arguments
 - Update IndexerResource creation to include redirect field
 - Update is_changed function to detect redirect parameter changes
 - Add integration tests for redirect parameter functionality

  Fixes #9 cc: @Fuochi 